### PR TITLE
Move from GitHub Releases to CrabNebula Cloud

### DIFF
--- a/.github/workflows/tauri.yaml
+++ b/.github/workflows/tauri.yaml
@@ -6,14 +6,39 @@ on:
     branches:
       - release
 
+# Just for the demo, ship to the QA environment
+env:
+  CN_ENV: qa
+
 jobs:
-  publish-tauri:
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Draft Release (CrabNebula Cloud)
+        uses: crabnebula-dev/cloud-release@dev
+        id: draft
+        with:
+          command: release draft ${{ secrets.CN_APP_ID }} --framework tauri
+          api-key: ${{ secrets.CN_API_KEY }}
+
+  build-and-upload:
+    name: Build and Upload Assets
+    needs: draft
     permissions:
       contents: write
     strategy:
       fail-fast: false
+      # This will create a job for each platform in the matrix
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+          - platform: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -24,8 +49,7 @@ jobs:
         with:
           node-version: 20
 
-      - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Dependencies (Ubuntu only)
         if: runner.os == 'Linux'
@@ -36,12 +60,27 @@ jobs:
       - name: Install Front-end Dependencies
         run: npm install # change this to npm or pnpm depending on which one you use
 
-      - uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build Tauri App
+        run: npm run tauri build -- -vv --target ${{ matrix.target }}
+
+      - name: Upload Build Artifacts (CrabNebula Cloud)
+        uses: crabnebula-dev/cloud-release@dev
+        id: upload
         with:
-          tagName: app-v__VERSION__ # the action automatically replaces \_\_VERSION\_\_ with the app version
-          releaseName: "App v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
-          releaseDraft: true
-          prerelease: false
+          command: release upload ${{ secrets.CN_APP_ID }} --framework tauri
+          api-key: ${{ secrets.CN_API_KEY }}
+
+  publish:
+    name: Publish Release to CrabNebula Cloud
+    needs: build-and-upload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crabnebula-dev/cloud-release@dev
+        id: publish
+        with:
+          command: release publish ${{ secrets.CN_APP_ID }} --framework tauri
+          api-key: ${{ secrets.CN_API_KEY }}


### PR DESCRIPTION
This PR moves a project from GitHub Releases via the [Tauri GitHub Action](https://github.com/tauri-apps/tauri-action) to CrabNebula Cloud. It unlocks the following benefits:

1. **Global asset distribution via CrabNebula's CDN:** GitHub releases serves build artifacts from a single AWS region, which can prove longer download times for users in varying geographies. CrabNebula cloud serves assets from a globally distributed CDN, resulting in faster downloads for your users.
2. **Over-the-air (OTA) automatic application updates:** CrabNebula Cloud has first-clas integration with the [Tauri updater](https://tauri.app/v1/guides/distribution/updater/) to ensure secure delivery of updates automatically to your users. This helps your users run the latest and most secure versions of your application with no effort.
3. **Metrics:** CrabNebula Cloud provides powerful insights and analytics around your application's distribution, including download count, geographic user distribution, OS distribution, and more.
4. **Team collaboration in CrabNebula Cloud:** CrabNebula Cloud is built for teams, sharing the load of release maintenance and management. CrabNebula Cloud integrates with CrabNebula's suite of developer tools to unlock higher levels of team collaboration.
5. **Nightly application builds/prerelease versions:** with this GitHub action, you can ship different application versions to your users, including pre-release variants for staging/trial purposes—think [Chrome Canary](https://www.google.com/chrome/canary/) vs. [Chrome](https://www.google.com/chrome/) final. To achieve this with CrabNebula Cloud, it's as simple as updating an environment variable per release branch.